### PR TITLE
Threads for slack

### DIFF
--- a/bots/faq_bot.py
+++ b/bots/faq_bot.py
@@ -62,6 +62,9 @@ class FAQBot(ActivityHandler):
             best_answer
         )
 
+        # TODO: we really need an acceptance test suite:
+        # - checks if we are in a slack channel
+        # - checks whether in are already in a thread
         if turn_context.activity.channel_id == "slack" and body["SlackMessage"] is not None:
             slack_message = SlackRequestBody(**body["SlackMessage"])
 

--- a/bots/faq_bot.py
+++ b/bots/faq_bot.py
@@ -5,7 +5,6 @@ from tensorflow.python.ops.variables import _UNKNOWN
 
 from taiwan_bot_sheet import TaiwanBotSheet, SpreadsheetContext
 from botbuilder.adapters.slack import SlackRequestBody
-from botbuilder.schema import (Activity)
 from botbuilder.core import ActivityHandler, TurnContext, ConversationState
 from .conversation_data import ConversationData
 from models.nlp_lite import UniversalSentenceEncoderLite

--- a/bots/faq_bot.py
+++ b/bots/faq_bot.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timezone
 import re
-
 import numpy as np
 from tensorflow.python.ops.variables import _UNKNOWN
 
 from taiwan_bot_sheet import TaiwanBotSheet, SpreadsheetContext
-from botbuilder.core import ActivityHandler, MessageFactory, TurnContext, ConversationState
-from botbuilder.schema import ChannelAccount
+from botbuilder.adapters.slack import SlackRequestBody
+from botbuilder.schema import (Activity)
+from botbuilder.core import ActivityHandler, TurnContext, ConversationState
 from .conversation_data import ConversationData
 from models.nlp_lite import UniversalSentenceEncoderLite
 
@@ -14,6 +14,7 @@ GOLD_CARD_REGEX = "gold card"
 SESSION_TIMEOUT_SECONDS = 300
 UNKNOWN_ANSWER = "Sorry, I can't help with that yet. Try to ask another question!"
 UNKNOWN_THRESHOLD = 0.5
+
 
 class FAQBot(ActivityHandler):
     """A model to find the most relevant answers for specific questions."""
@@ -30,8 +31,10 @@ class FAQBot(ActivityHandler):
         self.answers = {}
         self.questions_embeddings = {}
         for context in [SpreadsheetContext.GENERAL, SpreadsheetContext.GOLDCARD]:
-            self.questions[context], self.answers[context] = self.bot_sheet.get_questions_answers(context=context)
-            self.questions_embeddings[context] = self.encoder_model.extract_embeddings(self.questions[context])
+            self.questions[context], self.answers[context] = self.bot_sheet.get_questions_answers(
+                context=context)
+            self.questions_embeddings[context] = self.encoder_model.extract_embeddings(
+                self.questions[context])
 
     async def on_message_activity(self, turn_context: TurnContext):
         conversation_data = await self.conversation_data_accessor.get(
@@ -46,13 +49,33 @@ class FAQBot(ActivityHandler):
         conversation_data.recipient_id = turn_context.activity.recipient.id
 
         question = turn_context.activity.text
-        best_answer, most_similar_question, score = self._find_best_answer(question, conversation_data.context)
+        best_answer, most_similar_question, score = self._find_best_answer(
+            question, conversation_data.context)
         if score < UNKNOWN_THRESHOLD:
             best_answer = UNKNOWN_ANSWER
-        self.bot_sheet.log_answers(question, most_similar_question, best_answer, score, conversation_data.toJSON())
+        self.bot_sheet.log_answers(
+            question, most_similar_question, best_answer, score, conversation_data.toJSON())
+
+        body = turn_context.activity.channel_data
+
+        activity = turn_context.activity.create_reply(
+            best_answer
+        )
+
+        if turn_context.activity.channel_id == "slack" and body["SlackMessage"] is not None:
+            slack_message = SlackRequestBody(**body["SlackMessage"])
+
+            if slack_message.event.thread_ts is None:
+                channel_data = {
+                    "text": best_answer,
+                    "thread_ts": slack_message.event.ts
+                }
+
+                activity.channel_data = channel_data
+                activity.text = None
 
         return await turn_context.send_activity(
-            MessageFactory.text(best_answer)
+            activity
         )
 
     async def on_turn(self, turn_context: TurnContext):
@@ -74,7 +97,8 @@ class FAQBot(ActivityHandler):
         assert context in self.questions_embeddings
 
         question_embedding = self.encoder_model.extract_embedding(question)
-        scores = self.encoder_model.get_similarity_scores(question_embedding, self.questions_embeddings[context])
+        scores = self.encoder_model.get_similarity_scores(
+            question_embedding, self.questions_embeddings[context])
         most_similar_id = np.argmax(scores)
         most_similar_question = self.questions[context][most_similar_id]
         best_answer = self.answers[context][most_similar_id]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,13 @@
 absl-py==0.10.0
 adal==1.2.1
 aiofiles==0.5.0
+aiohttp==3.7.2
+aiounittest==1.3.0
 astunparse==1.6.3
+async-timeout==3.0.1
+attrs==20.2.0
 autopep8==1.5.4
+botbuilder-adapters-slack==4.10.1
 botbuilder-core==4.10.1
 botbuilder-schema==4.10.1
 botframework-connector==4.10.1
@@ -30,6 +35,7 @@ Keras-Preprocessing==1.1.2
 Markdown==3.2.2
 msal==1.2.0
 msrest==0.6.10
+multidict==5.0.0
 numpy==1.18.5
 oauth2client==4.1.3
 oauthlib==3.1.0
@@ -41,6 +47,7 @@ pycodestyle==2.6.0
 pycparser==2.20
 pydantic==1.6.1
 PyJWT==1.5.3
+pyslack==0.5.0
 python-dateutil==2.8.1
 requests==2.23.0
 requests-oauthlib==1.3.0
@@ -48,6 +55,7 @@ rsa==4.6
 scipy==1.4.1
 sentencepiece==0.1.91
 six==1.15.0
+slackclient==2.9.3
 starlette==0.13.6
 tensorboard==2.3.0
 tensorboard-plugin-wit==1.7.0
@@ -56,9 +64,11 @@ tensorflow-estimator==2.3.0
 tensorflow-hub==0.9.0
 termcolor==1.1.0
 toml==0.10.1
+typing-extensions==3.7.4.3
 urllib3==1.25.10
 uvicorn==0.11.8
 uvloop==0.14.0
 websockets==8.1
 Werkzeug==1.0.1
 wrapt==1.12.1
+yarl==1.6.2


### PR DESCRIPTION
## Description

Following docs for:

channel specific logic docs - https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-channeldata?view=azure-bot-service-4.0

`replyTo` field - https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0. `replyTo` only adds some metadata, but it doesn't create threads in slack.

The only way to create threads in slack is to pass in the channel-specific payload with a `thread_ts` AND the `text`

## How this is tested

On slack:

<img width="410" alt="Screenshot 2020-11-02 at 11 23 29 AM" src="https://user-images.githubusercontent.com/977460/97827035-11c00580-1cfe-11eb-9cf4-09c45c6456bf.png">

On facebook:

<img width="327" alt="Screenshot 2020-11-02 at 11 23 41 AM" src="https://user-images.githubusercontent.com/977460/97827044-184e7d00-1cfe-11eb-8f11-cc799539d426.png">


We should have better testing practices though - https://github.com/taiwangoldcard/taiwan-bot/issues/28

Fixes #30 