### PR TITLE
Remove @taiwan-bot mention

### DIFF
--- a/bots/faq_bot.py
+++ b/bots/faq_bot.py
@@ -77,6 +77,7 @@ class FAQBot(ActivityHandler):
         # We currently only support text-based conversations; no text, no service
         question = activity.text
         if question is not None:
+            question = self._clean_question(question)
             self._detect_and_set_context(question, conversation_data)
 
             best_answer, most_similar_question, score = self._find_best_answer(
@@ -120,6 +121,15 @@ class FAQBot(ActivityHandler):
         await super().on_turn(turn_context)
 
         await self.conversation_state.save_changes(turn_context)
+
+    # text is alread trimmed of whitespaces
+    def _clean_question(self, text: str):
+        clean_text = text
+        # remove slack mention
+        if text.startswith("@taiwan-bot"):
+            clean_text = ' '.join(text.split()[1:])
+
+        return clean_text
 
     def _detect_and_set_context(self, text: str, conversation_data):
         if conversation_data.timestamp is not None:

--- a/bots/faq_bot.py
+++ b/bots/faq_bot.py
@@ -122,12 +122,8 @@ class FAQBot(ActivityHandler):
 
         await self.conversation_state.save_changes(turn_context)
 
-    # text is alread trimmed of whitespaces
     def _clean_question(self, text: str):
-        clean_text = text
-        # remove slack mention
-        if text.startswith("@taiwan-bot"):
-            clean_text = ' '.join(text.split()[1:])
+        clean_text = text.replace("@taiwan-bot")
 
         return clean_text
 


### PR DESCRIPTION
The `@taiwan-bot` mention in slack mess up with the similarity score.
This PR removes any mention of it. The extra whitespaces in-between don't matter. 

<img width="1412" alt="Screenshot 2020-11-18 at 06 19 00" src="https://user-images.githubusercontent.com/3368263/99492193-16481780-29a8-11eb-963e-9e01ae300835.png">

<img width="1355" alt="Screenshot 2020-11-18 at 06 23 55" src="https://user-images.githubusercontent.com/3368263/99492205-1b0ccb80-29a8-11eb-87a4-ae923a2bd352.png">
