### PR TITLE
Log alternative questions

### DIFF
--- a/bots/faq_bot.py
+++ b/bots/faq_bot.py
@@ -171,7 +171,8 @@ class FAQBot(ActivityHandler):
         flat_scores = [score_array[0] for score_array in scores.tolist()]
         score_to_questions = dict(zip(flat_scores, self.questions[context]))
         # Top 5
-        top_alternate_scores = np.flip(np.sort(scores, axis=None))[1:6]
+        sorted_scores = np.flip(np.sort(scores, axis=None))
+        top_alternate_scores = sorted_scores[:5] if sorted_scores[0] < UNKNOWN_THRESHOLD else sorted_scores[1:6]
         def answer_for_score(score):
             score_id = np.where(scores == score)[0][0]
             return { "score": score.item(), "question": score_to_questions[score], "answer": self.answers[context][score_id] }

--- a/taiwan_bot_sheet.py
+++ b/taiwan_bot_sheet.py
@@ -75,7 +75,7 @@ class TaiwanBotSheet:
 
         return [questions, answers]
 
-    def log_answers(self, user_question, similar_question, answer, score, state):
+    def log_answers(self, user_question, similar_question, answer, score, state, alternative_questions):
         sheet = self.client.open(SPREADSHEET_LOG_FILE).worksheet(CONTEXTS[self.context]["sheet"])
         next_row = len(sheet.get_all_values()) + 1
         sheet.update( 'A' + str(next_row) , datetime.now().strftime("%d/%m/%Y %H:%M:%S"))
@@ -84,6 +84,7 @@ class TaiwanBotSheet:
         sheet.update( 'D' + str(next_row) , answer)
         sheet.update( 'E' + str(next_row) , score)
         sheet.update( 'F' + str(next_row) , state)
+        sheet.update( 'G' + str(next_row) , alternative_questions)
 
     def get_context(self):
         return CONTEXTS[self.context];


### PR DESCRIPTION
Log alternate questions (along with their answers & scores) for the top 5 next likely questions. This should help us quickly debug misses and even questions that haven't returned the correct answer. Below is an example of questions that basically mean the same thing yet return different answers:

![IMG_CA0A76BAC541-1](https://user-images.githubusercontent.com/4261980/101733705-362bb080-3afa-11eb-8aa6-61039c9c9fa7.jpeg)
